### PR TITLE
FIX: system persona non English save, missing bot pms

### DIFF
--- a/assets/javascripts/discourse/admin/models/ai-persona.js
+++ b/assets/javascripts/discourse/admin/models/ai-persona.js
@@ -20,6 +20,18 @@ const ATTRIBUTES = [
   "max_context_posts",
 ];
 
+const SYSTEM_ATTRIBUTES = [
+  "allowed_group_ids",
+  "enabled",
+  "system",
+  "priority",
+  "user_id",
+  "mentionable",
+  "default_llm",
+  "user",
+  "max_context_posts",
+];
+
 class CommandOption {
   @tracked value = null;
 }
@@ -97,7 +109,9 @@ export default class AiPersona extends RestModel {
   }
 
   updateProperties() {
-    let attrs = this.getProperties(ATTRIBUTES);
+    let attrs = this.system
+      ? this.getProperties(SYSTEM_ATTRIBUTES)
+      : this.getProperties(ATTRIBUTES);
     attrs.id = this.id;
     this.populateCommandOptions(attrs);
     return attrs;

--- a/lib/ai_bot/playground.rb
+++ b/lib/ai_bot/playground.rb
@@ -273,6 +273,12 @@ module DiscourseAi
           reply_post.post_custom_prompt.update!(custom_prompt: prompt)
         end
 
+        # since we are skipping validations and jobs we
+        # may need to fix participant count
+        if reply_post.topic.private_message? && reply_post.topic.participant_count < 2
+          reply_post.topic.update!(participant_count: 2)
+        end
+
         reply_post
       ensure
         publish_final_update(reply_post) if stream_reply

--- a/spec/lib/modules/ai_bot/playground_spec.rb
+++ b/spec/lib/modules/ai_bot/playground_spec.rb
@@ -135,6 +135,8 @@ RSpec.describe DiscourseAi::AiBot::Playground do
 
       last_post.topic.reload
       expect(last_post.topic.allowed_users.pluck(:user_id)).to include(persona.user_id)
+
+      expect(last_post.topic.participant_count).to eq(2)
     end
 
     it "picks the correct llm for persona in PMs" do


### PR DESCRIPTION
- FIX: only update system attributes when updating system persona
- FIX: update participant count by hand so bot messages show in inbox